### PR TITLE
feat: add task-specific criteria generation via haiku agent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,7 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]
+
+[tool.ruff.lint.per-file-ignores]
+# Prompt strings in f-strings should not be artificially wrapped
+"scripts/prompt-evaluator.py" = ["E501"]

--- a/scripts/prompt-evaluator.py
+++ b/scripts/prompt-evaluator.py
@@ -109,6 +109,10 @@ ONLY INVOKE RALPH-LOOP if task involves:
 - Feature implementation requiring build/test/lint cycles
 - Any work where quality gates (build, test, lint, coverage) apply
 
+BEFORE INVOKING: Use Task(model="haiku", subagent_type="Explore") to generate task-specific criteria.
+Agent prompt: "Task: [user request]. Template: [ralph-loop template below]. Explore codebase (5-10 files), generate 2-5 task-specific criteria, append after project criteria in 'When complete:' section. Do NOT duplicate existing criteria. Return enhanced template or UNCHANGED if no criteria found."
+If agent fails or returns UNCHANGED, use original template below.
+
 RALPH-LOOP to INVOKE:
 {wrapped_prompt}
 

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -133,6 +133,26 @@ class TestEvaluationRequest:
         assert "implement user auth" in context
         assert "When complete:" in context
 
+    def test_task_criteria_instruction_present(self):
+        """Evaluation context should include task-specific criteria instruction."""
+        output = run_hook("add rate limiting", config_exists=True)
+        context = output["hookSpecificOutput"]["additionalContext"]
+        assert "BEFORE INVOKING" in context
+        assert "Task(model=" in context or "haiku" in context
+        assert "task-specific criteria" in context
+
+    def test_task_criteria_instruction_has_deduplication(self):
+        """Task criteria instruction should mention deduplication."""
+        output = run_hook("implement caching", config_exists=True)
+        context = output["hookSpecificOutput"]["additionalContext"]
+        assert "NOT duplicate" in context or "Do NOT duplicate" in context
+
+    def test_task_criteria_instruction_has_fallback(self):
+        """Task criteria instruction should have fallback for agent failure."""
+        output = run_hook("refactor auth module", config_exists=True)
+        context = output["hookSpecificOutput"]["additionalContext"]
+        assert "agent fails" in context or "UNCHANGED" in context
+
 
 class TestOutputFormat:
     """Test output JSON format."""


### PR DESCRIPTION
## Summary
- Adds intelligent task-specific criteria generation using haiku agent before ralph-loop invocation
- Agent explores codebase (5-10 files) and generates 2-5 contextual completion criteria
- Falls back to original template if agent fails or returns UNCHANGED
- Includes ruff config to ignore E501 for prompt strings

## Test plan
- [x] Added 3 new tests for task criteria instruction