### PR TITLE
fix: Windows PowerShell compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Output <promise>COMPLETE</promise> when done."
 **Requirements:**
 - Claude Code 2.0.22+
 - [ralph-loop](https://github.com/anthropics/claude-code/tree/main/plugins/ralph-loop) plugin
+- Python 3.10+ with `pyyaml` installed (`pip install pyyaml`)
+
+> **Windows users:** Ensure Python is in your PATH and `pyyaml` is installed in the Python environment that Claude Code uses.
 
 ### Option 1: Via Marketplace (Recommended)
 

--- a/commands/init.md
+++ b/commands/init.md
@@ -13,14 +13,9 @@ Interactive wizard to configure ralph-loop for this project.
 
 ### Step 1: Check Existing Config
 
-```!
-if [ -f ".claude/this-little-wiggy/config.yml" ]; then
-  echo "CONFIG_EXISTS"
-  cat .claude/this-little-wiggy/config.yml
-else
-  echo "NO_CONFIG"
-fi
-```
+Use the Read tool to check if `.claude/this-little-wiggy/config.yml` exists:
+- If the file exists, note its contents
+- If the file does not exist (Read returns an error), proceed to Step 2
 
 If config exists and `--force` was NOT provided in `$ARGUMENTS`:
 - Use AskUserQuestion: Overwrite, Merge, or Cancel
@@ -104,11 +99,7 @@ Only include questions where criteria were discovered.
 
 ### Step 5: Write Config
 
-```!
-mkdir -p .claude/this-little-wiggy
-```
-
-Write `.claude/this-little-wiggy/config.yml` with user's selections:
+Use the Write tool to create `.claude/this-little-wiggy/config.yml` with user's selections (the Write tool will automatically create parent directories if they don't exist):
 
 ```yaml
 defaultMaxIterations: 10

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python -u \"${CLAUDE_PLUGIN_ROOT}/scripts/prompt-evaluator.py\"",
+            "command": "py -3 -u \"${CLAUDE_PLUGIN_ROOT}/scripts/prompt-evaluator.py\"",
             "timeout": 10
           }
         ]

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "py -3 -u \"${CLAUDE_PLUGIN_ROOT}/scripts/prompt-evaluator.py\"",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/run-hook.sh\"",
             "timeout": 10
           }
         ]

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,8 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/prompt-evaluator.py",
-            "timeout": 5
+            "command": "python -u \"${CLAUDE_PLUGIN_ROOT}/scripts/prompt-evaluator.py\"",
+            "timeout": 10
           }
         ]
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,13 @@ license = "MIT"
 authors = [
     { name = "severity1" }
 ]
+dependencies = [
+    "pyyaml>=6.0",
+]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0",
-    "pyyaml>=6.0",
 ]
 
 [tool.pytest.ini_options]

--- a/scripts/prompt-evaluator.py
+++ b/scripts/prompt-evaluator.py
@@ -29,7 +29,7 @@ def output_json(additional_context: str) -> None:
             "additionalContext": additional_context,
         }
     }
-    print(json.dumps(output))
+    print(json.dumps(output), flush=True)
 
 
 def pass_through(prompt: str) -> None:
@@ -64,9 +64,17 @@ def load_config() -> dict | None:
 
 def main() -> None:
     try:
+        # Handle Windows stdin encoding
+        if sys.platform == "win32":
+            import io
+            sys.stdin = io.TextIOWrapper(sys.stdin.buffer, encoding="utf-8")
+
         input_data = json.load(sys.stdin)
     except json.JSONDecodeError as e:
         print(f"Error: Invalid JSON input: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error reading input: {e}", file=sys.stderr)
         sys.exit(1)
 
     prompt = input_data.get("prompt", "")
@@ -132,4 +140,8 @@ FEEDBACK: If invoking ralph-loop, briefly tell the user: "Invoking ralph-loop (<
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:
+        print(f"Unhandled error in prompt-evaluator: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/prompt-evaluator.py
+++ b/scripts/prompt-evaluator.py
@@ -11,7 +11,14 @@ import os
 import sys
 from pathlib import Path
 
-import yaml
+try:
+    import yaml
+except ImportError:
+    print(
+        "Error: pyyaml is not installed. Install it with: pip install pyyaml",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 
 def output_json(additional_context: str) -> None:

--- a/scripts/run-hook.sh
+++ b/scripts/run-hook.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Cross-platform wrapper to invoke Python with the correct interpreter
+# - Linux/macOS: uses python3
+# - Windows (Git Bash/MSYS/Cygwin): uses py -3
+
+SCRIPT_DIR="$(dirname "$0")"
+HOOK_SCRIPT="$SCRIPT_DIR/prompt-evaluator.py"
+
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OS" == "Windows_NT" ]]; then
+    py -3 -u "$HOOK_SCRIPT"
+else
+    python3 -u "$HOOK_SCRIPT"
+fi


### PR DESCRIPTION
- Move pyyaml from dev to main dependencies (required at runtime)
- Replace bash-specific shell commands in init.md with cross-platform Claude tool instructions (Read/Write tools work on all platforms)
- Add graceful error handling when pyyaml is not installed
- Document Python and pyyaml requirements for Windows users

The bash syntax (if [ -f ... ], mkdir -p, cat) doesn't work in Windows PowerShell. Using Claude's built-in tools instead ensures cross-platform compatibility.